### PR TITLE
Investigate and fix page transition flicker

### DIFF
--- a/helixium-web/src/components/PageTransition.tsx
+++ b/helixium-web/src/components/PageTransition.tsx
@@ -20,15 +20,15 @@ const pageVariants = {
 
 const pageTransition: Transition = {
   type: "tween",
-  ease: "anticipate",
-  duration: 0.3,
+  ease: "easeInOut",
+  duration: 0.2,
 };
 
 export default function PageTransition({ children }: PageTransitionProps) {
   const location = useLocation();
 
   return (
-    <AnimatePresence mode="wait">
+    <AnimatePresence mode="wait" initial={false}>
       <motion.div
         key={location.pathname}
         initial="initial"

--- a/helixium-web/src/features/clickDashboard/index.tsx
+++ b/helixium-web/src/features/clickDashboard/index.tsx
@@ -3,12 +3,11 @@ import {
   clickCountReducerAtom,
 } from "@/store/atoms/clickCountAtom";
 import { Button, Flex, Text } from "@chakra-ui/react";
-import { useAtom, useStore } from "jotai";
+import { useAtom, useAtomValue } from "jotai";
 
 const ClickDashboard = ({ id }: { id: string }) => {
-  const store = useStore();
   const [, dispatch] = useAtom(clickCountReducerAtom);
-  const clickCountText = store.get(clickCountDisplayAtom);
+  const clickCountText = useAtomValue(clickCountDisplayAtom);
   return (
     <Flex flexDir={"column"} gap={2}>
       <Text>{id}</Text>

--- a/helixium-web/src/routes/index.tsx
+++ b/helixium-web/src/routes/index.tsx
@@ -4,14 +4,15 @@ import { createFileRoute } from "@tanstack/react-router";
 import ClickDashboard from "@/features/clickDashboard";
 import { createStore, Provider } from "jotai";
 
+// Create stores outside component to prevent recreation on re-renders
+const store1 = createStore();
+const store2 = createStore();
+
 export const Route = createFileRoute("/")({
   component: Index,
 });
 
 function Index() {
-  const store1 = createStore();
-  const store2 = createStore();
-
   return (
     <>
       <Flex flexDir={"column"} gap={4} maxW="800px" w="100%">


### PR DESCRIPTION
Fixes page transition flicker by ensuring proper state subscription, optimizing animation, and preventing store re-creation.

The flicker was caused by `ClickDashboard` not subscribing to atom updates, Jotai stores being recreated on every render, and an 'anticipate' easing in `AnimatePresence` causing visual artifacts. This PR addresses all three issues for smoother transitions.

---
[Slack Thread](https://dutchsdomain.slack.com/archives/C0973191GAD/p1755165861422489?thread_ts=1755165861.422489&cid=C0973191GAD)

<a href="https://cursor.com/background-agent?bcId=bc-79438603-b63e-46e5-a708-4468e9bf53e2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-79438603-b63e-46e5-a708-4468e9bf53e2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

